### PR TITLE
Fix: Explicitly require timeseries data to be of type 'count' or 'q'

### DIFF
--- a/xplt/timestructure.py
+++ b/xplt/timestructure.py
@@ -65,7 +65,9 @@ class TimePlotMixin:
                 raise ValueError("`particles` must be None when passing data via `timeseries`")
             if not isinstance(timeseries, dict):
                 if len(keys) != 1:
-                    raise ValueError(f"timeseries must be a dict with the following keys: {keys}")
+                    raise ValueError(
+                        f"timeseries must be a dict if plotting more than one property"
+                    )
                 timeseries = {keys[0]: timeseries}
             for ts in timeseries.values():
                 if not isinstance(ts, Timeseries):
@@ -423,10 +425,6 @@ class TimeBinPlot(ParticleHistogramPlot, TimePlotMixin):
         """
         kwargs = self._init_time_mixin(time_range=time_range, time_offset=time_offset, **kwargs)
 
-        self._timeseries_key_mapping = dict(
-            rate="count", cumulative="count", charge="q", current="q"
-        )
-
         super().__init__(
             "t_offset" if time_offset else "t",
             kind=kind,
@@ -469,8 +467,15 @@ class TimeBinPlot(ParticleHistogramPlot, TimePlotMixin):
 
     def _histogram(self, p, data, mask):
         if self._data_is_ts:
-            p = self._timeseries_key_mapping.get(p, p)
-            ts: Timeseries = get(data, p)
+            # TODO: derive 'q' or 'count' data, if only 'current', 'rate' or 'cumulative' data is given
+            if p in ("current", "charge"):
+                ts: Timeseries = get(data, "q")
+            elif self._count_based(p):
+                ts: Timeseries = get(data, "count")
+            else:
+                raise NotImplementedError(
+                    f"For timeseries data, plotting {p} is not yet supported."
+                )
             if self.range:
                 ts = ts.crop(*self.range)
             if self.bin_width and self.bin_count is None:
@@ -490,8 +495,7 @@ class TimeBinPlot(ParticleHistogramPlot, TimePlotMixin):
         """
 
         # check that the provided data is sufficient to plot the requested properties
-        keys = list(set([self._timeseries_key_mapping.get(k, k) for k in self.on_y_unique]))
-        timeseries = self._check_timeseries_data(particles, timeseries, keys=keys)
+        timeseries = self._check_timeseries_data(particles, timeseries, keys=self.on_y_unique)
         self._data_is_ts = timeseries is not None
 
         return super().update(


### PR DESCRIPTION
Timeseries data passed to `TimeBinPlot` without dict was treated as counts, even when kind was e.g. "rate". Since that is unintuitive and can lead to errors, we now explicitly require passing the dict in this case (except if kind is "counts").